### PR TITLE
feat: add a function to register custom handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ require("scrollbar").setup({
 })
 ```
 
+## Advanced
+One can define custom handlers mainly consisting of a name and a lua function that returns a list
+of mark lines as follows:
+
+```lua
+require("scrollbar.handlers").register(name, lines_function, [text, type, level])
+```
+
+So in order to mark every buffer's first three lines with an `x` of type `Misc` one can call:
+
+```lua
+require("scrollbar.handlers").register("my_marks", function(bufnr) return {1, 2, 3} end, "x", "Misc", 1)
+```
+
 ## Acknowledgements
 
 - [kevinhwang91/nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens) for implementation on how to hide search results

--- a/lua/scrollbar/handlers/init.lua
+++ b/lua/scrollbar/handlers/init.lua
@@ -1,0 +1,58 @@
+local utils = require("scrollbar.utils")
+
+local M = {}
+M.handlers = {}
+
+-- Register a function that returns marks for a given buffer
+--
+-- @param name Name of the handler
+-- @param lines_fun function that maps bufnr -> list of marks
+-- @param text marker text
+-- @param type marker type as defined in config
+-- @param level mark level
+function M.register(name, lines_fun, text, type, level)
+    M.handlers = vim.tbl_deep_extend(
+        "force",
+        M.handlers,
+        { {
+            name = name,
+            lines_fun = lines_fun,
+            text = text or "-",
+            type = type or "Misc",
+            level = level or 1
+        } }
+    )
+end
+
+function M.show()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local scrollbar_marks = utils.get_scrollbar_marks(bufnr)
+
+    for _, handler in ipairs(M.handlers) do
+        local handler_scrollbar_marks = {}
+        for _, result in pairs(handler.lines_fun(bufnr)) do
+            table.insert(handler_scrollbar_marks, {
+                line = result,
+                text = handler.text,
+                type = handler.type,
+                level = handler.level,
+            })
+        end
+        scrollbar_marks[handler.name] = handler_scrollbar_marks
+    end
+
+    utils.set_scrollbar_marks(bufnr, scrollbar_marks)
+end
+
+function M.hide()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local scrollbar_marks = utils.get_scrollbar_marks(bufnr)
+
+    for _, handler in ipairs(M.handlers) do
+        scrollbar_marks[handler.name] = nil
+    end
+
+    utils.set_scrollbar_marks(bufnr, scrollbar_marks)
+end
+
+return M

--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -156,7 +156,7 @@ M.setup = function(overrides)
             [[
         augroup scrollbar
             autocmd!
-            autocmd %s * lua require('scrollbar').render()
+            autocmd %s * lua require('scrollbar.handlers').show();require('scrollbar').render()
         augroup END
         ]],
             table.concat(config.autocmd.render, ",")


### PR DESCRIPTION
This PR closes #19.

Currently text, type and level are on a per-handler basis, with a function that returns line numbers to mark given a bufnr. We could consider shifting this and registering functions that return complete marker tables.