### PR TITLE
feat: add fold handling

### DIFF
--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -62,16 +62,30 @@ end
 
 local fix_invisible_lines = function(folds, rel_line_nr, offset)
     local abs_line_nr = rel_line_nr + offset
-    local aff_folds = find_affected_folds(folds, abs_line_nr)
 
-    for _, sur_fold in pairs(aff_folds) do
+    for _, sur_fold in pairs(folds) do
         -- abs_line_nr in fold
-        if sur_fold[1] < abs_line_nr then
+        if sur_fold[1] < abs_line_nr and sur_fold[1] >= vim.fn.line("w0") then
             rel_line_nr = rel_line_nr + (sur_fold[2] - sur_fold[1])
+            abs_line_nr = abs_line_nr + (sur_fold[2] - sur_fold[1])
         end
     end
 
     return rel_line_nr
+end
+
+local get_scroll_offset_diff = function(folds, abs_line_nr)
+    local aff_folds = find_affected_folds(folds, abs_line_nr)
+
+    local diff = 0
+    for _, sur_fold in pairs(aff_folds) do
+        -- abs_line_nr in fold
+        if sur_fold[1] < abs_line_nr then
+            diff = diff + (sur_fold[2] - sur_fold[1])
+        end
+    end
+
+    return diff
 end
 
 M.render = function()
@@ -161,7 +175,7 @@ M.render = function()
         end
     end
 
-    local diff_last = fix_invisible_lines(folds, last_visible_line, 0) - last_visible_line
+    local diff_last = get_scroll_offset_diff(folds, last_visible_line, 0)
     local scroll_offset = visible_lines - (last_visible_line - first_visible_line + 1) + diff_last
 
     for i = relative_first_line, relative_last_line, 1 do

--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -112,6 +112,10 @@ M.render = function()
     local relative_first_line = math.floor(first_visible_line * ratio) - math.floor(1 * ratio)
     local relative_last_line = math.floor(last_visible_line * ratio)
 
+    -- correct the folding diff
+    relative_first_line = fix_invisible_lines(folds, relative_first_line, first_visible_line)
+    relative_last_line = fix_invisible_lines(folds, relative_last_line, first_visible_line)
+
     local scrollbar_marks = utils.get_scrollbar_marks(0)
 
     local sorted_scrollbar_marks = {}
@@ -139,12 +143,12 @@ M.render = function()
         if mark.line <= total_lines then
             if
                 handle_marks[#handle_marks]
-                and math.floor(handle_marks[#handle_marks].line * ratio) == relative_mark_line
+                and fix_invisible_lines(folds, math.floor(handle_marks[#handle_marks].line * ratio), first_visible_line) == relative_mark_line
             then
                 utils.set_next_level_text(handle_marks[#handle_marks])
             elseif
                 other_marks[#other_marks]
-                and math.floor(other_marks[#other_marks].line * ratio) == relative_mark_line
+                and fix_invisible_lines(folds, math.floor(other_marks[#other_marks].line * ratio), first_visible_line) == relative_mark_line
             then
                 utils.set_next_level_text(other_marks[#other_marks])
             else
@@ -156,10 +160,6 @@ M.render = function()
             end
         end
     end
-
-
-    relative_first_line = fix_invisible_lines(folds, relative_first_line, first_visible_line)
-    relative_last_line = fix_invisible_lines(folds, relative_last_line, first_visible_line)
 
     local diff_last = fix_invisible_lines(folds, last_visible_line, 0) - last_visible_line
     local scroll_offset = visible_lines - (last_visible_line - first_visible_line + 1) + diff_last
@@ -176,6 +176,8 @@ M.render = function()
 
             for index, mark in ipairs(handle_marks) do
                 local relative_mark_line = math.floor(mark.line * ratio)
+                relative_mark_line = fix_invisible_lines(folds, relative_mark_line, first_visible_line)
+
                 if relative_mark_line >= i - 1 and relative_mark_line <= i then
                     handle_mark = mark
                     table.remove(handle_marks, index)
@@ -203,11 +205,12 @@ M.render = function()
         end
     end
 
-    scroll_offset = visible_lines - (last_visible_line - first_visible_line)
-
     for _, mark in pairs(other_marks) do
         if mark ~= nil then
-            local mark_line = first_visible_line + math.floor(tonumber(mark.line) * ratio) - scroll_offset
+            local relative_mark_line = math.floor(mark.line * ratio)
+            relative_mark_line = fix_invisible_lines(folds, relative_mark_line, first_visible_line)
+
+            local mark_line = first_visible_line + relative_mark_line - scroll_offset
 
             if mark_line >= 0 then
                 local mark_opts = {

--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -157,13 +157,15 @@ M.render = function()
         end
     end
 
-    local scroll_offset = visible_lines - (last_visible_line - first_visible_line)
 
     relative_first_line = fix_invisible_lines(folds, relative_first_line, first_visible_line)
     relative_last_line = fix_invisible_lines(folds, relative_last_line, first_visible_line)
 
+    local diff_last = fix_invisible_lines(folds, last_visible_line, 0) - last_visible_line
+    local scroll_offset = visible_lines - (last_visible_line - first_visible_line + 1) + diff_last
+
     for i = relative_first_line, relative_last_line, 1 do
-        local mark_line = math.min(first_visible_line + i, total_lines)
+        local mark_line = math.min(first_visible_line + i - scroll_offset, total_lines)
 
         if mark_line >= 0 then
             local handle_opts = {
@@ -200,6 +202,8 @@ M.render = function()
             vim.api.nvim_buf_set_extmark(0, NAMESPACE, mark_line, -1, handle_opts)
         end
     end
+
+    scroll_offset = visible_lines - (last_visible_line - first_visible_line)
 
     for _, mark in pairs(other_marks) do
         if mark ~= nil then


### PR DESCRIPTION
This pull request addresses issue #11 . It implements another offset for rendering the scrollbar handle with code foldings. However, even if the positioning is basically fixed, there are still some things to do:

- [x] re implement the scroll offset in order to draw the scrollbar handle correctly when scrolling over the bottom of the buffer
- [x] fix diagnostic and search mark positioning
- [ ] fix scrollbar behaviour when fold is at the bottom of the buffer such that the scrollbar completely would be drawn in the fold
- [ ] decide whether the scrollbar handle should resize when a folding is scrolled out of the way or not (and implement it of course)
- [ ] further testing and refactoring