### PR TITLE
fix: added noice to excluded_filetypes, since noice provides its own scrollbars

### DIFF
--- a/lua/scrollbar/config.lua
+++ b/lua/scrollbar/config.lua
@@ -61,6 +61,7 @@ local config = {
     excluded_filetypes = {
         "prompt",
         "TelescopePrompt",
+        "noice",
     },
     autocmd = {
         render = {


### PR DESCRIPTION
Hi!

I've added `noice` to the `excluded_filetypes`, since we do our own scrollbars.