### PR TITLE
feat: add gitsigns handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - Neovim >= 0.5.1
 - [nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens) (optional)
+- [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) (optional)
 
 ## Installation
 
@@ -71,6 +72,18 @@ If you want to leave only search marks and disable virtual text:
 require("scrollbar.handlers.search").setup({
     override_lens = function() end,
 })
+```
+
+## Git signs
+
+https://user-images.githubusercontent.com/889383/201331485-477677a7-40a9-4731-998a-34779f7123ff.mp4
+
+Display git changes in the sidebar. Requires [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) to be installed.
+
+To enable, add the following to your setup:
+
+```lua
+require("scrollbar.handlers.gitsigns").setup()
 ```
 
 ## Config
@@ -135,6 +148,27 @@ require("scrollbar").setup({
             cterm = nil,
             highlight = "Normal",
         },
+        GitAdd = {
+            text = "┆",
+            priority = 5,
+            color = nil,
+            cterm = nil,
+            highlight = "GitSignsAdd",
+        },
+        GitChange = {
+            text = "┆",
+            priority = 5,
+            color = nil,
+            cterm = nil,
+            highlight = "GitSignsChange",
+        },
+        GitDelete = {
+            text = "▁",
+            priority = 5,
+            color = nil,
+            cterm = nil,
+            highlight = "GitSignsDelete",
+        },
     },
     excluded_buftypes = {
         "terminal",
@@ -165,6 +199,7 @@ require("scrollbar").setup({
     handlers = {
         diagnostic = true,
         search = false, -- Requires hlslens to be loaded, will run require("scrollbar.handlers.search").setup() for you
+        gitsigns = false, -- Requires gitsigns.nvim
     },
 })
 ```
@@ -193,6 +228,12 @@ Mark type highlights are in the format of `Scrollbar<MarkType>` and
 - `ScrollbarHint`
 - `ScrollbarMiscHandle`
 - `ScrollbarMisc`
+- `ScrollbarGitAdd`
+- `ScrollbarGitAddHandle`
+- `ScrollbarGitChange`
+- `ScrollbarGitChangeHandle`
+- `ScrollbarGitDelete`
+- `ScrollbarGitDeleteHandle`
 
 ### Example config with [tokyonight.nvim](https://github.com/folke/tokyonight.nvim) colors
 

--- a/lua/scrollbar/config.lua
+++ b/lua/scrollbar/config.lua
@@ -54,6 +54,27 @@ local config = {
             cterm = nil,
             highlight = "Normal",
         },
+        GitAdd = {
+            text = "┆",
+            priority = 5,
+            color = nil,
+            cterm = nil,
+            highlight = "GitSignsAdd",
+        },
+        GitChange = {
+            text = "┆",
+            priority = 5,
+            color = nil,
+            cterm = nil,
+            highlight = "GitSignsChange",
+        },
+        GitDelete = {
+            text = "▁",
+            priority = 5,
+            color = nil,
+            cterm = nil,
+            highlight = "GitSignsDelete",
+        },
     },
     excluded_buftypes = {
         "terminal",
@@ -84,6 +105,7 @@ local config = {
     handlers = {
         diagnostic = true,
         search = false, -- Requires hlslens to be loaded, will run require("scrollbar.handlers.search").setup() for you
+        gitsigns = false, -- Requires gitsigns.nvim
     },
 }
 

--- a/lua/scrollbar/handlers/gitsigns.lua
+++ b/lua/scrollbar/handlers/gitsigns.lua
@@ -1,0 +1,89 @@
+local utils = require("scrollbar.utils")
+
+local M = {}
+
+---@param bufnr number
+local function get_gitsigns_marks(bufnr)
+    local config = require("scrollbar.config").get()
+    -- NOTE: get_hunks sometimes returns nil
+    local hunks = require("gitsigns").get_hunks(bufnr) or {}
+
+    local gitsigns_marks = {}
+
+    for _, hunk in ipairs(hunks) do
+        if hunk.type == "add" then
+            for line = hunk.added.start, hunk.added.start + hunk.added.count - 1 do
+                table.insert(gitsigns_marks, {
+                    line = line - 1,
+                    text = config.marks.GitAdd.text,
+                    type = "GitAdd",
+                    level = 1,
+                })
+            end
+        elseif hunk.type == "change" then
+            for line = hunk.added.start, hunk.added.start + hunk.added.count - 1 do
+                table.insert(gitsigns_marks, {
+                    line = line - 1,
+                    text = config.marks.GitChange.text,
+                    type = "GitChange",
+                    level = 1,
+                })
+            end
+        elseif hunk.type == "delete" then
+            -- NOTE: deleted lines are "collapsed" into a single mark that represents the deletion.
+            -- This is the same approach that gitsigns used for the signcolumn.
+            table.insert(gitsigns_marks, {
+                line = hunk.added.start - 1,
+                text = config.marks.GitDelete.text,
+                type = "GitDelete",
+                level = 1,
+            })
+        end
+    end
+
+    return gitsigns_marks
+end
+
+---@param bufnr number
+local function set_marks_in_buf(bufnr)
+    local scrollbar_marks = utils.get_scrollbar_marks(bufnr)
+    scrollbar_marks.gitsigns = get_gitsigns_marks(bufnr)
+    utils.set_scrollbar_marks(bufnr, scrollbar_marks)
+end
+
+M.handler = {
+    show = function()
+        -- NOTE: gitsigns does not include information which buffer was updated.
+        -- To avoid inconsistencies, the best bet is to update all buffers.
+        -- This could be taxing on performance, but the impact was not measured
+        -- during the initial implementation.
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if vim.api.nvim_buf_is_loaded(bufnr) then
+                set_marks_in_buf(bufnr)
+            end
+        end
+
+        require("scrollbar").render()
+    end,
+}
+
+function M.setup()
+    if not pcall(require, "gitsigns") then
+        vim.notify(
+            "[scrollbar.nvim] gitsigns.nvim module not available. Gitsigns handler was not loaded.",
+            vim.log.levels.WARN
+        )
+        return
+    end
+
+    local augroup = vim.api.nvim_create_augroup("ScrollbarGitSigns", {})
+
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "GitSignsUpdate",
+        group = augroup,
+        desc = "Update scrollbar marks after gitsigns updates",
+        callback = M.handler.show,
+    })
+end
+
+return M

--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -216,6 +216,10 @@ M.setup = function(overrides)
         require("scrollbar.handlers.search").setup()
     end
 
+    if config.handlers.gitsigns then
+        require("scrollbar.handlers.gitsigns").setup()
+    end
+
     if config.show_in_active_only then
         vim.cmd(string.format(
             [[


### PR DESCRIPTION
Displays sidebar marks for git hunks.


https://user-images.githubusercontent.com/889383/201331485-477677a7-40a9-4731-998a-34779f7123ff.mp4

After every `GitSignsUpdate` autocmd, all buffers are updated with marks based on latest hunks that gitsigns.nvim reports.

Requires [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) as it relies on the `GitSignsUpdate` to update the buffers and it reads the updates by calling `gitsigns.get_hunks`.

I haven't tested if the performance if affected to a great extent when there are many loaded buffers.

Fixes #53 