### PR TITLE
Feat: add ALE integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ require("scrollbar").setup({
         gitsigns = false, -- Requires gitsigns
         handle = true,
         search = false, -- Requires hlslens
+        ale = false, -- Requires ALE
     },
 })
 ```

--- a/lua/scrollbar/config.lua
+++ b/lua/scrollbar/config.lua
@@ -117,6 +117,7 @@ local config = {
         gitsigns = false, -- Requires gitsigns
         handle = true,
         search = false, -- Requires hlslens
+        ale = false, -- Requires ALE
     },
 }
 

--- a/lua/scrollbar/handlers/ale.lua
+++ b/lua/scrollbar/handlers/ale.lua
@@ -1,0 +1,52 @@
+local utils = require("scrollbar.utils")
+local config = require("scrollbar.config").get()
+
+local M = {}
+
+local function ale_marks_for(bufnr)
+    local ale_buffer_info = vim.g.ale_buffer_info[tostring(bufnr)]
+    if ale_buffer_info == nil then return {} end
+
+    local ale_loclist = ale_buffer_info.loclist
+
+    local rv = {}
+    for _,loclist_entry in pairs(ale_loclist) do
+        local mark_type = "Warn"
+        if loclist_entry.type == 'E' then
+            mark_type = "Error"
+        end
+
+        table.insert(rv, {
+            line = loclist_entry.lnum,
+            type = mark_type,
+            text = config.marks[mark_type].text[1],
+            level = config.marks[mark_type].priority
+        })
+    end
+
+    return rv
+end
+
+local function update_ale_marks()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local scrollbar_marks = utils.get_scrollbar_marks(bufnr)
+    scrollbar_marks.alesigns = ale_marks_for(bufnr)
+    utils.set_scrollbar_marks(bufnr, scrollbar_marks)
+    require("scrollbar").throttled_render()
+end
+
+function M.setup(opts)
+    local options = opts or {}
+    config = vim.tbl_deep_extend("force", config, options)
+
+    local augroup = vim.api.nvim_create_augroup("ScrollbarALE", {})
+
+    vim.api.nvim_create_autocmd("User", {
+        pattern = "ALELintPost",
+        group = augroup,
+        desc = "Update scrollbar marks after ALE does linting",
+        callback = update_ale_marks,
+    })
+end
+
+return M

--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -236,6 +236,10 @@ M.setup = function(overrides)
         require("scrollbar.handlers.search").setup()
     end
 
+    if config.handlers.ale then
+        require("scrollbar.handlers.ale").setup()
+    end
+
     if config.show_in_active_only then
         vim.cmd(string.format(
             [[


### PR DESCRIPTION
Add an integration to show ALE warnings/errors on the scrollbar. This can be activated as show below using the default config:
```lua
require("scrollbar").setup()
require("scrollbar.handlers.ale").setup({
    errors = {
        text = "⇐",
        highlight = "Error"
    },
    warnings = {
        text = "⇐",
        highlight = "Warn"
    }
})
```

If this PR is desirable, then I can amend it with updates to the plugin docs as required before merging.
