### PR TITLE
fix: refresh to avoid gitsigns loaded before scrollbar

### DIFF
--- a/lua/scrollbar/handlers/gitsigns.lua
+++ b/lua/scrollbar/handlers/gitsigns.lua
@@ -85,6 +85,7 @@ function M.setup()
         desc = "Update scrollbar marks after gitsigns updates",
         callback = M.handler.show,
     })
+    M.handler.show()
 end
 
 return M


### PR DESCRIPTION
gitsigns may be loaded before scrollbar, so we need a refresh at first.