### PR TITLE
fix: Scrollbar handle should not cover the content text

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ require("scrollbar").setup({
     throttle_ms = 100,
     handle = {
         text = " ",
+        blend = 30, -- Integer between 0 and 100. 0 for fully opaque and 100 to full transparent. Defaults to 30.
         color = nil,
         color_nr = nil, -- cterm
         highlight = "CursorColumn",

--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -134,6 +134,7 @@ M.render = function()
         if mark_line >= 0 then
             local handle_opts = {
                 virt_text_pos = "right_align",
+                hl_mode = 'blend',
             }
 
             local handle_mark = nil

--- a/lua/scrollbar/utils.lua
+++ b/lua/scrollbar/utils.lua
@@ -69,6 +69,7 @@ end
 M.set_highlights = function()
     local config = require("scrollbar.config").get()
 
+    local handle_blend = config.handle.blend or 30
     local handle_color = config.handle.color
         or M.highlight_to_hex_color(config.handle.highlight, "background", "CursorColumn", "#ffffff")
     local handle_color_nr = config.handle.color_nr
@@ -78,12 +79,13 @@ M.set_highlights = function()
     -- ScrollbarHandle
     vim.cmd(
         string.format(
-            "highlight %s ctermfg=%s ctermbg=%s guifg=%s guibg=%s",
+            "highlight %s ctermfg=%s ctermbg=%s guifg=%s guibg=%s blend=%s",
             M.get_highlight_name("", true),
             "NONE",
             handle_color_nr or 15,
             "NONE",
-            handle_color or "white"
+            handle_color or "white",
+            handle_blend
         )
     )
 
@@ -111,14 +113,15 @@ M.set_highlights = function()
         -- Scrollbar<MarkType>Handle
         vim.cmd(
             string.format(
-                "highlight %s cterm=%s ctermfg=%s ctermbg=%s gui=%s guifg=%s guibg=%s",
+                "highlight %s cterm=%s ctermfg=%s ctermbg=%s gui=%s guifg=%s guibg=%s blend=%s",
                 M.get_highlight_name(mark_type, true),
                 type_cterm,
                 type_color_nr or 0,
                 handle_color_nr or 15,
                 type_gui,
                 type_color,
-                handle_color
+                handle_color,
+                handle_blend
             )
         )
     end


### PR DESCRIPTION
Before:

![CleanShot 2023-03-16 at 23 45 36@2x](https://user-images.githubusercontent.com/1998490/225673489-f9697af0-a775-4985-933e-1eed42aa95b9.png)

After:

![CleanShot 2023-03-16 at 23 44 35@2x](https://user-images.githubusercontent.com/1998490/225672997-f9b67af7-fe27-4458-9d75-0fbfa9ecd1ba.png)


Changes:
- Make scrollbar handle blend. The blend defaults to 30.
- Add config option "handle.blend". User can change the blend value.