### PR TITLE
fix: only render scrollbar on valid windows

### DIFF
--- a/lua/scrollbar/init.lua
+++ b/lua/scrollbar/init.lua
@@ -202,10 +202,12 @@ M.on_scroll = function()
         end
     end
     for _, win in ipairs(wins) do
-        vim.api.nvim_win_call(win, function()
-            handlers.show()
-            M.render()
-        end)
+        if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_call(win, function()
+                handlers.show()
+                M.render()
+            end)
+        end
     end
 end
 


### PR DESCRIPTION
Problem: The `v:event` of the `on_scroll` function run on `WinScrolled` autocmd sometimes also includes the winid of the [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) window. When scrolling up/down quickly, the window may be closed by the time `WinScrolled` autocmd is run. This causes nvim-scrollbar to try to render the scrollbar in an invalid window. Neovim reports that as an error:

```
Error detected while processing WinScrolled Autocommands for "*": E5108: Error executing lua ...al/share/nvim/lazy/nvim-scrollbar/lua/scrollbar/init.lua:209: Invalid window id: 1016 stack traceback:
        [C]: in function 'nvim_win_call'
        ...al/share/nvim/lazy/nvim-scrollbar/lua/scrollbar/init.lua:209: in function 'on_scroll'
        [string ":lua"]:1: in main chunk
```




The fact that the window is invalid can be confirmed by adding a print statement that checks `vim.api.nvim_win_is_valid`.

![image](https://user-images.githubusercontent.com/889383/234844603-8139e737-56ba-4dfb-9177-11c6f2b72fa8.png)

Solution: Check if the window is valid before executing commands in that window.

Fixes https://github.com/petertriho/nvim-scrollbar/issues/88