### PR TITLE
fix: aligns rendering of hunks with gitsigns

### DIFF
--- a/lua/scrollbar/handlers/gitsigns.lua
+++ b/lua/scrollbar/handlers/gitsigns.lua
@@ -22,7 +22,19 @@ local function get_gitsigns_marks(bufnr)
                 })
             end
         elseif hunk.type == "change" then
-            for line = hunk.added.start, hunk.added.start + hunk.added.count - 1 do
+            -- A change can consist of both added and removed lines. In order to
+            -- use the same rendering as gitsigns, we need to separate the
+            -- changes within a single hunk.
+            for line = hunk.added.start + hunk.removed.count, hunk.added.start + hunk.added.count - hunk.removed.count + 1 do
+                table.insert(gitsigns_marks, {
+                    line = line - 1,
+                    text = config.marks.GitAdd.text,
+                    type = "GitAdd",
+                    level = 3,
+                })
+            end
+
+            for line = hunk.added.start, hunk.added.start + hunk.removed.count - 1 do
                 table.insert(gitsigns_marks, {
                     line = line - 1,
                     text = config.marks.GitChange.text,


### PR DESCRIPTION
# Introduction
nvim-scrollbar doesn't render the hunks in the same way as gitsigns. This becomes obvious when you put them side-to-side.

## Discrepancy between gitsigns and nvim-scrollbar
Here you can see the difference between gitsigns (colors on the left) and nvim-scrollbar (colors on the right).

<img width="1041" alt="image" src="https://github.com/petertriho/nvim-scrollbar/assets/6285202/a56b6c57-3ae5-42f4-acd9-0814437130bb">

## gitsigns and nvim-scrollbar in-sync
To align rendering, we need to split the changes in a "change" hunk to separate added rows from deleted rows.

<img width="1041" alt="image" src="https://github.com/petertriho/nvim-scrollbar/assets/6285202/34e34bcb-93de-4d40-bc13-4a22e36882b1">
