### PR TITLE
fix: add dropbar_menu to excluded_filetypes

### DIFF
--- a/lua/scrollbar/config.lua
+++ b/lua/scrollbar/config.lua
@@ -110,6 +110,8 @@ local config = {
         "terminal",
     },
     excluded_filetypes = {
+        "dropbar_menu",
+        "dropbar_menu_fzf",
         "cmp_docs",
         "cmp_menu",
         "noice",


### PR DESCRIPTION
Add [dropbar.nvim](https://github.com/Bekaboo/dropbar.nvim)'s `dropbar_menu` filetype to the list of excluded filetypes 