### PR TITLE
fix: add DressingInput to excluded_filetypes, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,9 @@ require("scrollbar").setup({
         "terminal",
     },
     excluded_filetypes = {
+        "dropbar_menu",
+        "dropbar_menu_fzf",
+        "DressingInput",
         "cmp_docs",
         "cmp_menu",
         "noice",

--- a/lua/scrollbar/config.lua
+++ b/lua/scrollbar/config.lua
@@ -112,6 +112,7 @@ local config = {
     excluded_filetypes = {
         "dropbar_menu",
         "dropbar_menu_fzf",
+        "DressingInput",
         "cmp_docs",
         "cmp_menu",
         "noice",


### PR DESCRIPTION
Added `DressingInput` from [dressing.nvim](https://github.com/stevearc/dressing.nvim) to the excluded filetypes. (this is the popup used for LSP rename, for example).

Added missing docs (excluded_filetypes->dropbar_menu) to the README (missing from my [last pr](https://github.com/petertriho/nvim-scrollbar/pull/108))