### PR TITLE
fix: add blink.cmp filetype to `excluded_filetypes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ require("scrollbar").setup({
         "terminal",
     },
     excluded_filetypes = {
+        "blink-cmp-menu",
         "dropbar_menu",
         "dropbar_menu_fzf",
         "DressingInput",

--- a/lua/scrollbar/config.lua
+++ b/lua/scrollbar/config.lua
@@ -110,6 +110,7 @@ local config = {
         "terminal",
     },
     excluded_filetypes = {
+        "blink-cmp-menu",
         "dropbar_menu",
         "dropbar_menu_fzf",
         "DressingInput",


### PR DESCRIPTION
Prevents adding a scrollbar to [blink.cmp](https://github.com/Saghen/blink.cmp), which is a new completion plugin. They use the `blink-cmp-menu` as the completion menu filetype ([source](https://github.com/Saghen/blink.cmp/blob/196711b89a97c953877d6c257c62f18920a970f3/lua/blink/cmp/completion/windows/menu.lua#L36))

| Before | After |
| ------ | ----- |
| <img width="222" alt="image" src="https://github.com/user-attachments/assets/cd2a4f08-bc5c-4e30-8e7a-5e5d7370f5b2" /> | <img width="226" alt="image" src="https://github.com/user-attachments/assets/07346056-bc42-4554-83d4-ec71d72387e7" />
