### PR TITLE
fix(search): resolve hlslens integration with module caching

### DIFF
--- a/lua/scrollbar/handlers/search.lua
+++ b/lua/scrollbar/handlers/search.lua
@@ -83,13 +83,18 @@ M.setup = function(overrides)
     local config = require("scrollbar.config").get()
     config.handlers.search = true
 
-    local hlslens_config = vim.tbl_deep_extend("force", {
-        build_position_cb = function(plist, _, _, _)
-            M.handler.show(plist.start_pos)
-        end,
-    }, overrides or {})
+    -- Directly modify hlslens.config to bypass Lua module caching issue
+    local hlslens_config = require("hlslens.config")
+    hlslens_config.build_position_cb = function(plist, _, _, _)
+        M.handler.show(plist.start_pos)
+    end
 
-    hlslens.setup(hlslens_config)
+    -- Apply user overrides if provided
+    if overrides then
+        for k, v in pairs(overrides) do
+            hlslens_config[k] = v
+        end
+    end
 
     vim.cmd([[
         augroup scrollbar_search_hide


### PR DESCRIPTION
## Problem
The hlslens search handler was not working when hlslens was loaded before
   nvim-scrollbar due to Lua's module caching mechanism.

### Root Cause
1. When hlslens loads first, it calls `require('hlslens.config')` which runs
   the `init()` function and caches the config with `build_position_cb = nil`
2. Later when `search.setup()` calls `hlslens.setup()` with the callback,
   hlslens stores it in hlslens._config but the cached config module is never updated
3. The `init()` function only runs once when the module is first required,
   so subsequent `hlslens.setup()` calls don't update the cached config

### Reproduction
With this plugin loading order:
```lua
require('hlslens').setup()  -- Loads first, caches config with nil callback
require('scrollbar.handlers.search').setup()  -- Config already cached
```
Result: Search marks don't appear on scrollbar

## Solution
Directly modify the cached hlslens.config object instead of calling `hlslens.setup()`.
Since Lua tables are passed by reference, modifying the cached config object updates it everywhere.

Note: Alternatively, users can avoid this issue by removing `require('hlslens').setup()` from their configuration and letting nvim-scrollbar handle hlslens initialization.

### Changes
- Remove `hlslens.setup()` call
- Directly access hlslens.config via `require("hlslens.config")`
- Set `build_position_cb` directly on the config object

### Benefits
- Works regardless of plugin loading order
- Preserves all existing hlslens configuration

## Environment
- OS: macOS (Darwin 25.0.0)
- Neovim: NVIM v0.11.4
- Plugin Manager: [vim-plug](https://github.com/junegunn/vim-plug)

#83

